### PR TITLE
feat: Use CSS Variables for Prism themes

### DIFF
--- a/www/gatsby-browser.tsx
+++ b/www/gatsby-browser.tsx
@@ -4,6 +4,7 @@ import "./src/styles/fonts.css"
 import "./src/styles/reset.css"
 import { ThemeProvider } from "./src/styles/theme-provider"
 import "./src/styles/global.css"
+import "./src/styles/prism/prism-themes.css"
 
 export const onRouteUpdate: GatsbyBrowser["onRouteUpdate"] = () => {
   if (process.env.NODE_ENV === `production` && typeof window.plausible !== `undefined`) {

--- a/www/src/components/mdx/code.tsx
+++ b/www/src/components/mdx/code.tsx
@@ -47,7 +47,7 @@ export const Code = ({
       language={language}
       theme={resolvedTheme === `light` ? lightTheme : darkTheme}
     >
-      {({ className, style, tokens, getLineProps, getTokenProps }) => (
+      {({ className, tokens, getLineProps, getTokenProps }) => (
         <div className={codeBlockWrapper} data-testid="code-wrapper">
           {(title || originalLanguage) && (
             <Box
@@ -79,7 +79,7 @@ export const Code = ({
             </Box>
           )}
           <div className={gatsbyHighlightStyle}>
-            <pre className={composeClassNames(className, gatsbyHighlightPreStyle)} style={style}>
+            <pre className={composeClassNames(className, gatsbyHighlightPreStyle)}>
               <code className={composeClassNames(`language-${language}`, codeStyle)}>
                 {tokens.map((line, i) => {
                   const lineProps = getLineProps({ line, key: i })

--- a/www/src/components/mdx/code.tsx
+++ b/www/src/components/mdx/code.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import Highlight, { defaultProps } from "prism-react-renderer"
-import lightTheme from "prism-react-renderer/themes/nightOwlLight"
-import darkTheme from "prism-react-renderer/themes/nightOwl"
 import { useTheme } from "themes-utils"
+import { nightOwlLight } from "../../styles/prism/nightOwlLight"
+import { nightOwl } from "../../styles/prism/nightOwl"
+import { themeWithCssVariables } from "../../styles/prism/prism-utils"
 import { Box } from "../primitives"
 import { calculateLinesToHighlight, getLanguage, GetLanguageInput, languageOverride } from "../../utils/code"
 import { Copy } from "./copy"
@@ -18,6 +19,9 @@ import {
   tokenLineStyle,
 } from "./code.css"
 import { composeClassNames } from "../../utils/box"
+
+const { theme: lightTheme } = themeWithCssVariables(nightOwlLight)
+const { theme: darkTheme } = themeWithCssVariables(nightOwl)
 
 type CodeProps = {
   codeString: string

--- a/www/src/components/typography/tailwind-typography.css.ts
+++ b/www/src/components/typography/tailwind-typography.css.ts
@@ -806,11 +806,8 @@ export const proseBaseStyle: SelectorMap = {
     },
   },
   pre: {
-    color: colorPalette.gray[200],
-    backgroundColor: {
-      light: colorPalette.gray[800],
-      dark: colorPalette.gray[900],
-    },
+    color: vars.color.codeBlockText,
+    backgroundColor: vars.color.codeBlockBg,
     overflowX: `auto`,
   },
   "pre code": {

--- a/www/src/styles/prism/nightOwl.ts
+++ b/www/src/styles/prism/nightOwl.ts
@@ -1,0 +1,109 @@
+// Original: https://github.com/sdras/night-owl-vscode-theme
+import type { CustomPrismTheme } from "./prism-utils"
+
+export const nightOwl: CustomPrismTheme = {
+  id: `nightOwl`,
+  plain: {
+    color: `#d6deeb`,
+    backgroundColor: `#011627`,
+  },
+  styles: [
+    {
+      types: [`changed`],
+      style: {
+        color: `rgb(162, 191, 252)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`deleted`],
+      style: {
+        color: `rgba(239, 83, 80, 0.56)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`inserted`, `attr-name`],
+      style: {
+        color: `rgb(173, 219, 103)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`comment`],
+      style: {
+        color: `rgb(99, 119, 119)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`string`, `url`],
+      style: {
+        color: `rgb(173, 219, 103)`,
+      },
+    },
+    {
+      types: [`variable`],
+      style: {
+        color: `rgb(214, 222, 235)`,
+      },
+    },
+    {
+      types: [`number`],
+      style: {
+        color: `rgb(247, 140, 108)`,
+      },
+    },
+    {
+      types: [`builtin`, `char`, `constant`, `function`],
+      style: {
+        color: `rgb(130, 170, 255)`,
+      },
+    },
+    {
+      // This was manually added after the auto-generation
+      // so that punctuations are not italicised
+      types: [`punctuation`],
+      style: {
+        color: `rgb(199, 146, 234)`,
+      },
+    },
+    {
+      types: [`selector`, `doctype`],
+      style: {
+        color: `rgb(199, 146, 234)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`class-name`],
+      style: {
+        color: `rgb(255, 203, 139)`,
+      },
+    },
+    {
+      types: [`tag`, `operator`, `keyword`],
+      style: {
+        color: `rgb(127, 219, 202)`,
+      },
+    },
+    {
+      types: [`boolean`],
+      style: {
+        color: `rgb(255, 88, 116)`,
+      },
+    },
+    {
+      types: [`property`],
+      style: {
+        color: `rgb(128, 203, 196)`,
+      },
+    },
+    {
+      types: [`namespace`],
+      style: {
+        color: `rgb(178, 204, 214)`,
+      },
+    },
+  ],
+}

--- a/www/src/styles/prism/nightOwlLight.ts
+++ b/www/src/styles/prism/nightOwlLight.ts
@@ -1,0 +1,97 @@
+// Original: https://github.com/sdras/night-owl-vscode-theme
+import type { CustomPrismTheme } from "./prism-utils"
+
+export const nightOwlLight: CustomPrismTheme = {
+  id: `nightOwlLight`,
+  plain: {
+    color: `#403f53`,
+    backgroundColor: `#FBFBFB`,
+  },
+  styles: [
+    {
+      types: [`changed`],
+      style: {
+        color: `rgb(162, 191, 252)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`deleted`],
+      style: {
+        color: `rgba(239, 83, 80, 0.56)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`inserted`, `attr-name`],
+      style: {
+        color: `rgb(72, 118, 214)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`comment`],
+      style: {
+        color: `rgb(152, 159, 177)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`string`, `builtin`, `char`, `constant`, `url`],
+      style: {
+        color: `rgb(72, 118, 214)`,
+      },
+    },
+    {
+      types: [`variable`],
+      style: {
+        color: `rgb(201, 103, 101)`,
+      },
+    },
+    {
+      types: [`number`],
+      style: {
+        color: `rgb(170, 9, 130)`,
+      },
+    },
+    {
+      // This was manually added after the auto-generation
+      // so that punctuations are not italicised
+      types: [`punctuation`],
+      style: {
+        color: `rgb(153, 76, 195)`,
+      },
+    },
+    {
+      types: [`function`, `selector`, `doctype`],
+      style: {
+        color: `rgb(153, 76, 195)`,
+        fontStyle: `italic`,
+      },
+    },
+    {
+      types: [`class-name`],
+      style: {
+        color: `rgb(17, 17, 17)`,
+      },
+    },
+    {
+      types: [`tag`],
+      style: {
+        color: `rgb(153, 76, 195)`,
+      },
+    },
+    {
+      types: [`operator`, `property`, `keyword`, `namespace`],
+      style: {
+        color: `rgb(12, 150, 155)`,
+      },
+    },
+    {
+      types: [`boolean`],
+      style: {
+        color: `rgb(188, 84, 84)`,
+      },
+    },
+  ],
+}

--- a/www/src/styles/prism/prism-themes.css.ts
+++ b/www/src/styles/prism/prism-themes.css.ts
@@ -1,0 +1,17 @@
+import { globalStyle } from "@vanilla-extract/css"
+import { darkThemeClass } from "../themes/dark.css"
+import { lightThemeClass } from "../themes/light.css"
+import { nightOwl } from "./nightOwl"
+import { nightOwlLight } from "./nightOwlLight"
+import { themeWithCssVariables } from "./prism-utils"
+
+const { variables: lightTheme } = themeWithCssVariables(nightOwlLight)
+const { variables: darkTheme } = themeWithCssVariables(nightOwl)
+
+globalStyle(lightThemeClass, {
+  vars: lightTheme,
+})
+
+globalStyle(darkThemeClass, {
+  vars: darkTheme,
+})

--- a/www/src/styles/prism/prism-utils.ts
+++ b/www/src/styles/prism/prism-utils.ts
@@ -1,0 +1,63 @@
+// Modified from https://github.com/FormidableLabs/prism-react-renderer/pull/160/
+
+import type { PrismTheme } from "prism-react-renderer"
+
+type StyleObj = { [key: string]: string }
+
+export type CustomPrismTheme = PrismTheme & {
+  id: string
+}
+
+const flattenThemeTypes = (theme: CustomPrismTheme): PrismTheme => {
+  const { plain, styles } = theme
+
+  return {
+    plain: { ...plain },
+    styles: styles.reduce((acc: PrismTheme["styles"], x) => {
+      const { types, style, ...rest } = x
+      const flatStyle = types.map((type) => ({
+        types: [type],
+        style: { ...style },
+        ...rest,
+      }))
+      acc.push(...flatStyle)
+      return acc
+    }, []),
+  }
+}
+
+/**
+ * Returns a PrismTheme that is visually equivalent to `theme`
+ * but with CSS Variables instead of fixed values (e.g.
+ * `var(--plain-color)` instead of `"#F8F8F2"`).
+ *
+ * Also returns a mapping from CSS Variable to value (i.e. an
+ * object with key `--plain-color` and value `"#F8F8F2"`)
+ */
+export const themeWithCssVariables = (theme: CustomPrismTheme): { theme: PrismTheme; variables: StyleObj } => {
+  const flatTheme = flattenThemeTypes(theme)
+  const variables: StyleObj = {}
+
+  const { plain, styles } = flatTheme
+
+  Object.entries(plain).forEach(([key, value]) => {
+    const varName = `--plain-${key}`
+    variables[varName] = value as string
+    // Will not modify `theme` because `flattenThemeTypes`
+    // deep clones the original `theme` object
+    plain[key] = `var(${varName})`
+  })
+
+  // `types` should have length 1
+  styles.forEach(({ style, types }) => {
+    Object.entries(style).forEach(([key, value]) => {
+      const varName = `--${types[0]}-${key}`
+      variables[varName] = value as string
+      // Will not modify `theme` because `flattenThemeTypes`
+      // deep clones the original `theme` object
+      style[key] = `var(${varName})`
+    })
+  })
+
+  return { theme: flatTheme, variables }
+}

--- a/www/src/styles/tokens/colors.ts
+++ b/www/src/styles/tokens/colors.ts
@@ -1,4 +1,6 @@
 import { transparentize } from "utils"
+import { nightOwl } from "../prism/nightOwl"
+import { nightOwlLight } from "../prism/nightOwlLight"
 
 const navBgTransparency = 0.85
 
@@ -329,8 +331,8 @@ export const lightThemeColors: typeof nullColors = {
   navigationBg: transparentize(colorPalette.white, navBgTransparency),
   ghostBg: transparentize(colorPalette.blueGray[900], 0.1),
   copyButtonBg: colorPalette.white,
-  codeBlockText: `#403f53`,
-  codeBlockBg: `#fbfbfb`,
+  codeBlockText: nightOwlLight.plain.color as string,
+  codeBlockBg: nightOwlLight.plain.backgroundColor as string,
 }
 
 export const darkThemeColors: typeof nullColors = {
@@ -354,6 +356,6 @@ export const darkThemeColors: typeof nullColors = {
   navigationBg: transparentize(colorPalette.blueGray[900], navBgTransparency),
   ghostBg: transparentize(colorPalette.white, 0.1),
   copyButtonBg: transparentize(colorPalette.blue[600], 0.4),
-  codeBlockText: `#d6deeb`,
-  codeBlockBg: `#011627`,
+  codeBlockText: nightOwl.plain.color as string,
+  codeBlockBg: nightOwl.plain.backgroundColor as string,
 }

--- a/www/src/styles/tokens/colors.ts
+++ b/www/src/styles/tokens/colors.ts
@@ -302,6 +302,8 @@ export const nullColors = {
   navigationBg: ``,
   ghostBg: ``,
   copyButtonBg: ``,
+  codeBlockText: ``,
+  codeBlockBg: ``,
 }
 
 export type Colors = keyof typeof nullColors
@@ -327,6 +329,8 @@ export const lightThemeColors: typeof nullColors = {
   navigationBg: transparentize(colorPalette.white, navBgTransparency),
   ghostBg: transparentize(colorPalette.blueGray[900], 0.1),
   copyButtonBg: colorPalette.white,
+  codeBlockText: `#403f53`,
+  codeBlockBg: `#fbfbfb`,
 }
 
 export const darkThemeColors: typeof nullColors = {
@@ -350,4 +354,6 @@ export const darkThemeColors: typeof nullColors = {
   navigationBg: transparentize(colorPalette.blueGray[900], navBgTransparency),
   ghostBg: transparentize(colorPalette.white, 0.1),
   copyButtonBg: transparentize(colorPalette.blue[600], 0.4),
+  codeBlockText: `#d6deeb`,
+  codeBlockBg: `#011627`,
 }


### PR DESCRIPTION
Previously the HTML had the dark theme and only then on re-hydration the other theme would come in. You could reproduce this by explicitly choosing the light mode and then hard refreshing.

This converts prism themes to use CSS variables and then I set them depending on the theme. This way there is no FOUC and the HTML only has the CSS variable.
